### PR TITLE
fix Lost atoms ERROR

### DIFF
--- a/rolling/in.granhertz.rolling_sphere
+++ b/rolling/in.granhertz.rolling_sphere
@@ -81,4 +81,4 @@ dump		1 all custom ${dumpfreq} ${name}_hertz.dump &
 
 thermo_style	custom step cpu atoms ke
 
-run		9500000
+run		8500000

--- a/rolling/in.granlinear.rolling_sphere
+++ b/rolling/in.granlinear.rolling_sphere
@@ -81,4 +81,4 @@ dump		1 all custom ${dumpfreq} ${name}_linear.dump &
 
 thermo_style	custom step cpu atoms ke
 
-run		9500000
+run		8500000


### PR DESCRIPTION
#3 Lost atoms error occurs when particles leave the simulation box. In this case, the rolling particle rolls for a long time, leaving this box.
In order to avoid this error, keeping the particle inside the box, the number of steps was reduced.